### PR TITLE
Explicit include cstdint header for gcc 13

### DIFF
--- a/source/common/amdisa_utility.h
+++ b/source/common/amdisa_utility.h
@@ -7,6 +7,7 @@
 // C++ libraries.
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace amdisa
 {


### PR DESCRIPTION
According to the https://gcc.gnu.org/gcc-13/porting_to.html, gcc 13 doesn't implicitly include `<cstdint>` anymore, so we need to include it explicitly.